### PR TITLE
docs: add dialplan page in a new architecture section

### DIFF
--- a/docs/architecture/dialplan.md
+++ b/docs/architecture/dialplan.md
@@ -1,0 +1,26 @@
+# Dialplan
+
+Fundamentally, Hams Over IP is a telephone exchange, and as such there is a defined dialplan. While the specifics are more complicated, the underlying principles are summarized below.
+
+## Regions First
+
+- Routing of 1xxx, 1xxxx, 1xxxxx, and 9xxxx goes to the US1 server
+- Routing of 2xxxx, 2xxxxx goes to the EU server
+- Routing of 3xxxx, 3xxxxx goes to the Asia/Pacific server
+
+All of these servers are interconnected, but this first number will indicate where the target extension is initially routed.
+
+## Length Indicates Role
+
+- Two or three digits represent links to other VOIP networks; see the "Linked VOIP Networks" category in the side navigation for more details on these
+- Four digit are used for admin extensions
+- Five digit numbers are used for conference, RF link, and audio extensions
+- Six digit numbers are used for end-user and trunk extensions
+
+## Callsign Routing
+
+Non-numerical extensions are matched against callsign routing, which is mapped to the corresponding extension. Note that this only applies to end-user and trunk extensions.
+
+## RadioID Routing
+
+[RadioIDs](https://radioid.net) are 7-digit unique identifiers for amateur callsigns issued by a platform-agnostic body. These identifiers are frequently used for digital voice modes as radio ids (thus the name). When provided by the registering user, these values are mapped to the corresponding user's extension. Note that this is provided as an opt-in process and manually maintained, so these should be viewed as a convenience or vanity compared to the tranditionally assigned extensions.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -90,7 +90,8 @@ nav:
   - Files (Right Click and Select Save File As):
     - Side Car Template: files/SideCar_Template_A4.xls
     - Phone Wallpaper: wallpaper/wallpaper.md 
-
+  - Architecture:
+    - Dialplan: architecture/dialplan.md
   - Wiki:
     - Contributing: 
       - Overview of the Wiki: wiki/overview.md


### PR DESCRIPTION
## What?

Add a new "Architecture" menu category and an initial page on the dialplan.

## Why?

This is my first step to improving transparency in the architecture that powers HOIP. The intent of this change is to promote participation from those wishing to see HOIP as a place to learn about PBXes, as well as to help call attention to all of the capabilities that HOIP supports.

## How?

This information is based on what I've learned from identifying patterns in the extensions documented through the various systems. So it is likely incomplete and lacking in the _intent_ behind the decision. I'd welcome feedback pointing me to resources I can review to present a more complete picture.

## Testing?

N/a

## Screenshots (optional)

N/a

## Anything Else?

N/a