### PR TITLE
Create guide for OBi 202 ATA

### DIFF
--- a/docs/endpoints/hard_phones/OBi202.md
+++ b/docs/endpoints/hard_phones/OBi202.md
@@ -1,0 +1,64 @@
+# Setting Up an OBi 202 Adapter with Hams over IP
+
+I have an analog telephone adapter (ATA) that lets me connect <abbr title="Plain Old Telephone System">POTS</abbr> phones to VoIP services.  Here's how to get your ATA working with Hams over IP.
+
+
+## Logging in to the Device
+
+I already have another VoIP service configured, so I will be configuring what the device calls **Service Provider 2** (or sometimes "B").
+
+OBiTALK devices can be configured online with [OBiNET](https://www.obitalk.com/obinet/pg/obhdev), but my directions will cover setting up the device manually, using its built-in Web server;  for example, `http://192.0.2.2`.
+
+When using the built-in Web server, you will find that almost all advanced options are greyed out until you un-check that row's Default checkbox.
+
+
+## Service Provider Profile Configuration
+
+On the left-hand side, under **Service Providers**, click on **ITSP Profile B**.
+
+Under the General section:
+*  Name: Hams over IP
+*  SignalingProtocol: <abbr title="Session Initiation Protocol">SIP</abbr>
+
+![ITSPProfile](https://user-images.githubusercontent.com/19931245/231046347-6e35f7b6-c6be-4260-bb5c-abb35194a735.png)
+
+
+SIP section:
+*  ProxyServer: `pbx-us1.hamsoverip.com` (or your server name)
+*  ProxyServerPort: `5160`
+*  ProxyServerTransport: `UDP`
+*  OutboundProxy: `pbx-us1.hamsoverip.com` (or your server name)
+*  OutboundProxyPort: `5160`
+*  RegisterExpires: `3600`
+*  X_SessionRefresh: unchecked
+*  X_LineSeizeSubscribeExpires: `30`
+
+![ITSPProfileSIP](https://user-images.githubusercontent.com/19931245/231046413-f732be9a-2985-479a-9721-c3f2fa9d894c.png)
+
+
+## Voice Service Configuration
+
+Under the **Voice Services** heading, click on **SP2 Service**.
+
+*  Enable: checked
+*  X_RegisterEnable: checked
+*  X_UserAgentPort: `5081`
+*  AuthUserName: your extension
+*  AuthPassword: your password
+*  URI: (blank)
+*  X_EnforceRequestUserID: checked
+*  X_SRTP: `Use SRTP When Possible`
+
+Under **CallerIDName**, enter your caller ID as you want other people to see it.  I used my full name and call sign.  I'm not sure if HoIP overrides this setting or not.
+
+![VoiceServices](https://user-images.githubusercontent.com/19931245/231046325-be5aa42f-0aab-459e-a0ba-e9a537c7f3cc.png)
+
+
+## That's it!
+
+Finally, reboot the device and see if the extension will register.  Now, pick up whatever telephone you've plugged into your ATA and see if you get a dial tone!
+
+![Yes, this Western Electric 2500DMG now supports VoIP calling!](https://user-images.githubusercontent.com/19931245/231046451-33b4da9a-7c52-47d4-bdb7-96ecfef54618.jpg)
+(Yes, this 50-year-old phone actually works with <abbr title="Hams over IP">HoIP</abbr>!  The OBi ATA is under my desk and not pictured.)
+
+73, Colin Cogle, W1DNS.


### PR DESCRIPTION
This guide shows how to set up an OBiTALK (now owned by Poly) OBi 202 analog telephone adapter to connect to Hams over IP.  Screenshots and photos are included.

Hopefully this how-to can be used to set up similar devices, too.