### PR TITLE
Telegram Crosslink, OBi202 update, SMS ASL3.0 update, RF Links List update

### DIFF
--- a/docs/guides/endpoints/hardphones/obi-202.md
+++ b/docs/guides/endpoints/hardphones/obi-202.md
@@ -6,7 +6,7 @@ I have an analog telephone adapter (ATA) that lets me connect POTS phones to VoI
 
 I already have another VoIP service configured, so I will be configuring what the device calls **Service Provider 2** (or sometimes "B").
 
-OBiTALK devices can be configured online with [OBiNET](https://www.obitalk.com/obinet/pg/obhdev), but my directions will cover setting up the device manually, using its built-in Web server;  for example, `http://192.0.2.2`.
+OBiTALK devices used to be configurable online with OBiNET but this service has now been discontinued by Polycom in 2024, so my directions will cover setting up the device manually, using its built-in Web server; for example, `http://192.0.2.2`.
 
 When using the built-in Web server, you will find that almost all advanced options are greyed out until you un-check that row's Default checkbox.
 
@@ -45,13 +45,13 @@ Under the **Voice Services** heading, click on **SP2 Service**.
 * AuthPassword: your password
 * URI: (blank)
 * X_EnforceRequestUserID: checked
-* X_SRTP: `Use SRTP When Possible`
+* X_SRTP: `Disable SRTP`
 
 Under **CallerIDName**, enter your caller ID as you want other people to see it.  I used my full name and call sign.  I'm not sure if HoIP overrides this setting or not.
 
 ![VoiceServices](https://user-images.githubusercontent.com/19931245/231046325-be5aa42f-0aab-459e-a0ba-e9a537c7f3cc.png)
 
-## That's it!
+## That's it
 
 Finally, reboot the device and see if the extension will register.  Now, pick up whatever telephone you've plugged into your ATA and see if you get a dial tone!
 
@@ -60,7 +60,7 @@ Finally, reboot the device and see if the extension will register.  Now, pick up
 
 ----
 
-!!! info "Last updated 2023-04-11 by Colin W1DNS"
+!!! note "Written by Colin W1DNS, last updated 2025-08-08"
 
 *[HoIP]: Hams Over IP
 *[POTS]: Plain Old Telephone System

--- a/docs/guides/rf-links/remove-sms-asl-3.md
+++ b/docs/guides/rf-links/remove-sms-asl-3.md
@@ -13,7 +13,7 @@ To create a private node for HamsOverIP on ASL3
 7. next select # 4 HUB w/no radio
 8. enter Callsign of the node or repeater
 9. now click on Update Node 1995
-10. you will not need to ener a node password
+10. you will not need to enter a node password
 11. you should have the following:
 
     - 1 Node number : 1995
@@ -25,7 +25,7 @@ To create a private node for HamsOverIP on ASL3
     - 7 Node access list : Open
     - 8 Interface Tune CLI
 
-12. select Back with arow keys
+12. select Back with arrow keys
 13. select #2 Restart Asterisk
 14. select #4 Update IAX port (make a note of it you will need it later)
 15. select &lt;Back&gt;
@@ -67,6 +67,9 @@ nano extensions.conf
 insert the following: We are still using 1995 as the node number
 
 ```ini
+[global]
+NODE2 = 1995  << add to the global stanza
+
 [hoipphone]
 exten => ${NODE2},1,Ringing()
 same => n,Wait(1)
@@ -84,14 +87,20 @@ same => n,Playback(rpt/connected)
 same => n,rpt(${NODE2}|P)
 ```
 
+Change numbers after `digits/` to your Allstar node number
+
 CTRL - X to exit
 Y for Yes and press enter to save it
 reboot for changes to take effect.
+
+You have offically setup your private node with no text messaging for HamsOverIP.
+
+Now follow the steps in our [configuration guide](./configure-rf-links.md) to create your Dial string, and then go to our [ticketing system :material-open-in-new:](https://helpdesk.hamsoverip.com/osticket/){ target="_blank" } and create a ticket for an RF Node number - Be Patient as this does take time.
 
 Please note: You will have to send a ticket in to HOIP to adjust your IAX2 String to now match to your new private node number. If you require guidance on the format of the IAX2 string, then please check our [configuration guide](./configure-rf-links.md).  Once that's done, test to confirm the SMS beacons are gone.
 
 Note: You will NOT see who is connected or hear the connection. This is normal.
 
-You will see on your Allmon3 or Supermon dashboards when someone Keys up on HamsOverIP when Connected to your node. With this setup you can drop the private node if a person is creating problems and reconnect it at a later time.
+You will see on your Allmon3 or Supermon dashboards when someone keys up on HamsOverIP when Connected to your node. With this setup you can drop the private node if a person is creating problems and reconnect it at a later time.
 
-!!! note "Last updated 2025-07-22 Brad N8PC"
+!!! note "Written by Brad N8PC, last updated 2025-08-16"

--- a/docs/guides/user/chat-services.md
+++ b/docs/guides/user/chat-services.md
@@ -5,15 +5,11 @@ Realtime communication is one of the keys off our organization. In addition to t
 Currently, we use the following platforms:
 
 * [Discord](#discord-server) _(primary)_
-* [Telegram](#telegram-group)
+* [Telegram](#telegram-groups)
 * [Crosslink Lobby Chat](#crosslink-lobby-chat) _(if you don't have Discord or Telegram)_
 * [Matrix](#matrix-room)
 
-At this time, only the Telegram group is bridged to the [:fontawesome-brands-discord: #lobby](https://discord.com/channels/966060559961296956/966806535466524714) channel of our Discord server.  The Matrix channel is still standalone, but there's usually someone around to help.
-
 !!! warning "**Please observe our [Code of Conduct](../../policies/code-of-conduct.md) at all times whilst using any of these services**"
-
-<!--Keep in mind that all of these platforms are not setup as independent entities. These are all linked together as a way of extending the BYOD (Bring Your Own Device) ethos. In this case it's more of a Choose Your Own Platform kind of thing.-->
 
 ## Discord Server
 
@@ -32,27 +28,31 @@ After joining, we ask that you do a couple of things:
     * Change the field that says `Server Nickname`
     * If it says you need to pay for Discord Nitro, you are doing it wrong. Server Nicknames are free to set.
 
-## Telegram Group
+## Telegram Groups
 
-We also have a Telegram Group that users can use if they choose to.
+We also have a couple of Telegram Groups that users can use if they choose to.
 
-[:fontawesome-brands-telegram: Join our Telegram group :material-open-in-new:](https://t.me/hamsoverip){ target="_blank" }
+* [:fontawesome-brands-telegram: Official Telegram group :material-open-in-new:](https://t.me/hamsoverip){ target="_blank" }  
+  This group is standalone, and **not bridged** to any other room.
 
-This group is bridged into the [:fontawesome-brands-discord: #crosslink-lobby :material-open-in-new:](https://discord.com/channels/966060559961296956/1401835917773242378){ target="_blank" } channel of our Discord server so that everyone in each group can participate in conversations or seek help.
+* [:fontawesome-brands-telegram: HamsOverIP Crosslink Lobby :material-open-in-new:](https://t.me/+yWg1smGTdMI2NTUx){ target="_blank" }  
+  This group **is bridged** as part of the [Crosslink Lobby Chat](#crosslink-lobby-chat) system.
 
 ## Crosslink Lobby Chat
 
-We now have a brand-new [Crosslink Lobby Chat :material-open-in-new:](https://helpdesk.hamsoverip.com/crosslink/){ target="_blank" } which you can use if you don't use Discord.  Anything you type here will appear in the [:fontawesome-brands-discord: #crosslink-lobby :material-open-in-new:](https://discord.com/channels/966060559961296956/1401835917773242378){ target="_blank" } channel on our Discord server, and also in our [Telegram group](#telegram-group).
+We now have a brand-new [Crosslink Lobby Chat :material-open-in-new:](https://helpdesk.hamsoverip.com/crosslink/){ target="_blank" } which you can use if you don't use Discord or Telegram.  Anything you type here will also appear in (and vice versa):
 
-This channel is accessible to anyone who is in our Discord server, so please don't use it to share passwords or IP addresses.  If you require assistance from one of our amazing Support Team, put out a call in this chat then you can determine an alternative way to discuss your support issue.  Please be patient though!
+* [:fontawesome-brands-discord: #crosslink-lobby :material-open-in-new:](https://discord.com/channels/966060559961296956/1401835917773242378){ target="_blank" } channel on our Discord server
+* [:fontawesome-brands-telegram: HamsOverIP Crosslink Lobby :material-open-in-new:](https://t.me/+yWg1smGTdMI2NTUx){ target="_blank" } group on Telegram.
+
+This service is accessible to all regardless of which method you use, so please don't use it to share passwords or IP addresses.  If you require assistance from one of our amazing Support Team, put out a call in this chat then you can determine an alternative way to discuss your support issue.  Please be patient though!
 
 ## Matrix Room
 
 We also have a public room on the matrix.org public instance.
 
-[:simple-matrix: Join our Matrix room :material-open-in-new:](https://matrix.to/#/#hamsoverip:matrix.org){ target="_blank" }
-
-This room is currently standalone and _not_ bridged to our Discord or Telegram rooms.
+* [:simple-matrix: Join our Matrix room :material-open-in-new:](https://matrix.to/#/#hamsoverip:matrix.org){ target="_blank" }  
+   This room is standalone, and **not bridged** to any other room.
 
 <!--This room is also bridged into our Discord server in the [:fontawesome-brands-discord: #lobby](https://discord.com/channels/966060559961296956/966806535466524714) channel.-->
 

--- a/docs/reference/rf-links-list.md
+++ b/docs/reference/rf-links-list.md
@@ -51,13 +51,13 @@ To request an RF Link, please go to the [Helpdesk](https://helpdesk.hamsoverip.c
 | **15030** | K2HZE ALLSTAR 41605                          |  | Tom, K2HZE<br />Ext: 100345<br />Email: |
 | **15031** | K0NNK ALLSTAR 57686                          |  | Collin, K0NNK<br />Ext: 100251<br />Email: <k0nnk@qsl.net> |
 | **15032** | KZ4FOX ALLSTAR 547942                        |  | Mark, KZ4FOX<br />Ext: 100359<br />Email: <mark@kz4fox.com> |
-| **15033** | K0NNK ALLSTAR 57686                          |  | Collin, K0NNK<br />Ext: 100251<br />Email: <k0nnk@qsl.net> |
+| **15033** | N0EBB ALLSTAR 47734                          |  | Don, N0EBB<br />Ext: 100379<br />Email: |
 | **15034** | K9PSL ALLSTAR 431420                         |  | Paul, K9PSL<br />Ext: 100403<br />Email: <k9psl@yahoo.com> |
 | **15035** | J62DX ALLSTAR 1758                           |  | Frans, J62DX<br />Ext: 100425<br />Email: <j69ds@hotmail.com> |
 | **15036** | K4YWE ALLSTAR 54341                          |  | Danny, K4YWE<br />Ext: 100432<br />Email: <danny@wxmesg.com> |
 | **15037** | WA4KIK ALLSTAR 53812                         |  | Danny, K4YWE<br />Ext: 100432<br />Email: <danny@wxmesg.com> |
 | **15038** | KM4ECM ALLSTAR 41557                         |  | Ryan, KM4ECM<br />Ext: 100256<br />Email: <ryan@turnrye.com> |
-| **15039** | KF4BOG ALLSTAR 58098                         |  | Michael, KF4BOG<br />Ext: 100015<br />Email: <mikekf4bog@gmail.com> |
+| **15039** | Murphy Radio Network (MRN)                   | We are a growing Amateur Radio Network located in North Central Texas. This network (group) is in favor of supporting both Analog & Digital Modes. | Ron, KJ5APA<br />Ext: 101247<br />Email: <kj5apa@icloud.com> |
 | **15040** | KG4ORQ ALLSTAR 58088                         |  | David, KG4ORQ<br />Ext: 100426<br />Email: <dave9549@gmail.com> |
 | **15041** | WE0FUN ALLSTAR 28299                         |  | Jeff, K0JSC<br />Ext: 100125<br />Email: <info@we0fun.com> |
 | **15042** | N4LMC ALLSTAR 46077                          |  |  |

--- a/docs/whats-new.md
+++ b/docs/whats-new.md
@@ -7,6 +7,18 @@ icon: material/newspaper-variant
 
 Here are the latest updates from the Wiki
 
+!!! info "2025-08-16"
+
+    * **Update: [Chat Services](./guides/user/chat-services.md)**
+        - added instructions relating to the new Telegram Crosslink Lobby room
+    * **Update: [OBi 202 Adapter](./guides/endpoints/hardphones/obi-202.md)**
+        - remove an obsolete link, and correct an error relating to SRTP - **thanks to Mauro AG7BI**
+    * **Update: [Remove SMS from ASL version 3.0](./guides/rf-links/remove-sms-asl-3.md)**
+        - couple of typos, a missing config item, and updated instructions - thanks to **Brad N8PC**
+    * **Update: [RF Links List](./reference/rf-links-list.md)**
+        - corrected incorrect entry, and updated one that had been reissued
+
+
 !!! info "2025-08-07"
 
     * **New: [Cisco 8800 Series](./guides/endpoints/hardphones/cisco-88xx.md)**


### PR DESCRIPTION
Update: added instructions relating to the new Telegram Crosslink Lobby room
Update: OBi202 page to remove an obsolete link, and correct an error relating to SRTP
Update: Remove SMS ASL, couple of typos, a missing config item, and updated instructions
Update: RF Links List, corrected incorrect entry, and update one that had been reissued.
Update: navigational changes